### PR TITLE
Revert "Ignition also needed 'coreos.config.url' in place of 'cloud-config-url'"

### DIFF
--- a/data/profiles/install-coreos.ipxe
+++ b/data/profiles/install-coreos.ipxe
@@ -5,6 +5,6 @@ set base-url <%=repo%>
 # JUST BOOT AND RUN COREOS
 # kernel ${base-url}/<%=version%>/coreos_production_pxe.vmlinuz coreos.autologin cloud-config-url=http://<%=server%>:<%=port%>/api/current/templates/pxe-cloud-config.yml
 #
-kernel ${base-url}/<%=version%>/coreos_production_pxe.vmlinuz console=tty0 console=<%=comport%>,115200n8 coreos.autologin coreos.first_boot=1 coreos.config.url=<%=installScriptUri%>
+kernel ${base-url}/<%=version%>/coreos_production_pxe.vmlinuz console=tty0 console=<%=comport%>,115200n8 coreos.autologin coreos.first_boot=1 cloud-config-url=<%=installScriptUri%>
 initrd ${base-url}/<%=version%>/coreos_production_pxe_image.cpio.gz
 boot || prompt --key 0x197e --timeout 2000 Press F12 to investigate || exit shell


### PR DESCRIPTION
Reverts tgelter/on-http#2